### PR TITLE
Add 100% width to BoardCard title link

### DIFF
--- a/src/components/boards/BoardCard.js
+++ b/src/components/boards/BoardCard.js
@@ -110,12 +110,14 @@ class BoardCard extends Component {
                       textDecoration: "none",
                       height: "64px",
                       paddingLeft: "24px",
+                      width: "100%"
                     }
                   : {
                       color: "black",
                       textDecoration: "none",
                       height: "64px",
                       paddingLeft: "24px",
+                      width: "100%"
                     }
               }
             >


### PR DESCRIPTION
#20 If the board name was too short the link wouldn't use the full width.
![image](https://user-images.githubusercontent.com/1170107/47587333-2b1c6300-d928-11e8-91ae-4990bd3a2b02.png) ![image](https://user-images.githubusercontent.com/1170107/47587414-674fc380-d928-11e8-9772-d9847f73a915.png)
